### PR TITLE
Enhancement/use xdg base dirs

### DIFF
--- a/src/gentodo/commands.py
+++ b/src/gentodo/commands.py
@@ -7,7 +7,9 @@ import click
 from gentodo import bugs
 
 OLD_PATH = os.path.expanduser("~/.local/share/todo/todo.json")
-STORAGE_DIR = os.path.expanduser("~/.local/share/gentodo")
+STORAGE_DIR = os.path.join(
+    os.getenv('XDG_DATA_HOME', os.path.expanduser("~/.local/share")),
+    "gentodo")
 TODO_FILE = os.path.join(STORAGE_DIR, "todo.json")
 
 class Gentodo:

--- a/src/gentodo/config.py
+++ b/src/gentodo/config.py
@@ -7,14 +7,16 @@ import sys
 import os
 import subprocess
 
-STORAGE_DIR = os.path.expanduser("~/.config/gentodo")
-CONFIG_FILE = os.path.join(STORAGE_DIR, "config.toml")
+CONFIG_DIR = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+    "gentodo")
+CONFIG_FILE = os.path.join(CONFIG_DIR, "config.toml")
 
 class Config:
     '''Class to handle the configuration file settings'''
     def __init__(self):
         if not os.path.isfile(CONFIG_FILE):
-            os.makedirs(STORAGE_DIR)
+            os.makedirs(CONFIG_DIR)
             with open(CONFIG_FILE, "w", encoding="utf_8") as config:
                 config.write("[gentodo]\n")
         self.data = self.load_config()


### PR DESCRIPTION
This adds the ability to use `XDG_DATA_HOME` for the data storage base dir, and `XDG_CONFIG_HOME` for the configuration base dir.

If not set it will fall back to `~/.local/share` and `~/.config`, as before.

(Also renames the variable `STORAGE_DIR` to `CONFIG_DIR` in config.py, for consistency :))

Tests:
When running `env XDG_DATA_HOME=/tmp/gtd-data XDG_CONFIG_HOME=/tmp/gtd-config gentodo CMD`, dirs and files were created in the defined places.
When the env vars are omitted it still uses the previous default and uses/creates the files there.